### PR TITLE
Extend library about domains definitions

### DIFF
--- a/src/Virtualization/Libvirt/LibvirtConnection.cs
+++ b/src/Virtualization/Libvirt/LibvirtConnection.cs
@@ -34,6 +34,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Xml;
+using System.Xml.Linq;
 
 namespace IDNT.AppBasics.Virtualization.Libvirt
 {
@@ -295,12 +296,12 @@ namespace IDNT.AppBasics.Virtualization.Libvirt
                 throw new LibvirtException();
         }
 
-        public void CreateDomain(XmlDocument definition)
+        public void CreateDomain(XDocument definition)
         {
-            if (definition == null || definition.DocumentElement == null)
+            if (definition == null)
                 throw new ArgumentException("Definition cannot be null");
             
-            IntPtr domainPtr = NativeVirDomain.CreateXML(this.ConnectionPtr, definition.DocumentElement.OuterXml, 0);
+            IntPtr domainPtr = NativeVirDomain.CreateXML(this.ConnectionPtr, definition.ToString(), 0);
             
             if (IntPtr.Zero == domainPtr)
                 throw new LibvirtException();

--- a/src/Virtualization/Libvirt/LibvirtConnection.cs
+++ b/src/Virtualization/Libvirt/LibvirtConnection.cs
@@ -286,22 +286,23 @@ namespace IDNT.AppBasics.Virtualization.Libvirt
             }
         }
 
-        public void DestroyDomain(LibvirtDomain domain)
-        {
-            if (domain == null)
-                throw new ArgumentException("Domain cannot be null");
-            IntPtr domainPtr = domain.DomainPtr;
-            
-            if (NativeVirDomain.Destroy(domainPtr) == -1)
-                throw new LibvirtException();
-        }
-
         public void CreateDomain(XDocument definition)
         {
             if (definition == null)
                 throw new ArgumentException("Definition cannot be null");
             
             IntPtr domainPtr = NativeVirDomain.CreateXML(this.ConnectionPtr, definition.ToString(), 0);
+            
+            if (IntPtr.Zero == domainPtr)
+                throw new LibvirtException();
+        }
+
+        public void DefineDomain(XDocument definition)
+        {
+            if (definition == null)
+                throw new ArgumentException("Definition cannot be null");
+            
+            IntPtr domainPtr = NativeVirDomain.DefineXML(this.ConnectionPtr, definition.ToString());
             
             if (IntPtr.Zero == domainPtr)
                 throw new LibvirtException();

--- a/src/Virtualization/Libvirt/LibvirtConnection.cs
+++ b/src/Virtualization/Libvirt/LibvirtConnection.cs
@@ -285,6 +285,27 @@ namespace IDNT.AppBasics.Virtualization.Libvirt
             }
         }
 
+        public void DestroyDomain(LibvirtDomain domain)
+        {
+            if (domain == null)
+                throw new ArgumentException("Domain cannot be null");
+            IntPtr domainPtr = domain.DomainPtr;
+            
+            if (NativeVirDomain.Destroy(domainPtr) == -1)
+                throw new LibvirtException();
+        }
+
+        public void CreateDomain(XmlDocument definition)
+        {
+            if (definition == null || definition.DocumentElement == null)
+                throw new ArgumentException("Definition cannot be null");
+            
+            IntPtr domainPtr = NativeVirDomain.CreateXML(this.ConnectionPtr, definition.DocumentElement.OuterXml, 0);
+            
+            if (IntPtr.Zero == domainPtr)
+                throw new LibvirtException();
+        }
+
         /// <summary>
         /// Enumerates all running as well as defined domains
         /// </summary>

--- a/src/Virtualization/Libvirt/LibvirtDomain.cs
+++ b/src/Virtualization/Libvirt/LibvirtDomain.cs
@@ -521,6 +521,25 @@ namespace IDNT.AppBasics.Virtualization.Libvirt
             return NativeVirDomain.Shutdown(_domainPtr) == 0;
         }
 
+        public bool Destroy()
+        {
+            return NativeVirDomain.Destroy(this._domainPtr) == 0;
+        }
+        
+        public bool Undefine()
+        {
+            int ret = NativeVirDomain.IsPersistent(this.DomainPtr);
+            switch (ret)
+            {
+                case 1:
+                    return NativeVirDomain.Undefine(this.DomainPtr) == 0;
+                case 0:
+                    throw new LibvirtException("Cannot undefine transient domain");
+                default: //-1 and others
+                    throw new LibvirtException();
+            }
+        }
+
         /// <summary>
         /// Shutdown a domain, the domain object is still usable thereafter, but the domain OS is being stopped. Note that the guest OS may ignore the request.
         /// </summary>

--- a/src/Virtualization/Libvirt/Native/VirError.cs
+++ b/src/Virtualization/Libvirt/Native/VirError.cs
@@ -117,7 +117,7 @@ namespace IDNT.AppBasics.Virtualization.Libvirt.Native
             string extra = !string.IsNullOrEmpty(Str1) ? " " + Str1 : String.Empty;
             extra += !string.IsNullOrEmpty(Str2) ? (string.IsNullOrEmpty(extra) ? "" : " ") + Str2 : String.Empty;
             extra += !string.IsNullOrEmpty(Str3) ? (string.IsNullOrEmpty(extra) ? "" : " ") + Str3 : String.Empty;
-            return string.Format($"{level.ToString()} #{code.ToString()} {Message}{extra}");
+            return $"{level.ToString()} #{code.ToString()} {Message}{extra}";
         }
     }
 }


### PR DESCRIPTION
Now LibvirtConnection can define persistent domain or crete transient from XML data.
LibvirtDomain can now be destroyed or undefined.